### PR TITLE
fix(文件写入): 清理章节标题以防止 ENOENT 错误

### DIFF
--- a/main.js
+++ b/main.js
@@ -41,12 +41,17 @@ const main = async () => {
     for (let i = 0; i < finishSections.length; i++) {
         const section = finishSections[i];
         const sectionInfo = await getSection(section.id);
-        const sectionPath = `${bookName}/${
-            section.index
-        }.${sectionInfo.title.replaceAll("/", "\\")}.md`;
+
+        // 替换章节标题中的特殊字符
+        const safeTitle = sectionInfo.title.replaceAll("/", "-").replaceAll("：", "-");
+
+        // 使用安全的标题来创建文件路径
+        const sectionPath = `${bookName}/${section.index}.${safeTitle}.md`;
+
         fs.writeFileSync(sectionPath, sectionInfo.content);
         console.log(`第 ${section.index} 章下载完成`);
     }
+
 
     console.log(`小册 ${bookName} 下载完成`);
 };


### PR DESCRIPTION
本次提交对写入文件时的章节标题进行了清理。之前，特殊字符（如斜杠和冒号）没有得到妥善处理，导致出现 'ENOENT: no such file or directory' 错误。

通过用破折号替换这些特殊字符，确保了文件路径在不同的文件系统中都是有效的，从而避免了 ENOENT 错误。